### PR TITLE
Closes #8: Introduce and test capability to read files from URLs

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Package: datasetjson
 Type: Package
 Title: Read and Write CDISC Dataset JSON Files
-Version: 0.0.1
+Version: 0.0.1.9000
 Authors@R: c(
     person(given = "Mike",
            family = "Stackhouse",

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,8 @@
-# datasetjson 0.0.0.9999
+# datasetjson 0.0.1.9000
 
-Intial development version of datasetjson, introducing core objects, readers and writers.
+- Capability to read and validate Dataset JSON files from URLs has been added (#8)
+
+# datasetjson 0.0.1
+
+Initial development version of datasetjson, introducing core objects, readers and writers.
+

--- a/R/read_dataset_json.R
+++ b/R/read_dataset_json.R
@@ -1,9 +1,10 @@
 #' Read a Dataset JSON to datasetjson object
 #'
-#' This function validated a dataset JSON file on disk against the Dataset JSON schema, and if valid
-#' returns a datasetjson object
+#' This function validates a dataset JSON file against the Dataset JSON schema,
+#' and if valid returns a datasetjson object. The Dataset JSON file can be
+#' either a file path on disk of a URL which contains the Dataset JSON file.
 #'
-#' @param file File path on disk, or a pre-loaded Dataset JSON file in a single element character string
+#' @param file File path or URL of a Dataset JSON file
 #'
 #' @return datasetjson object
 #' @export
@@ -12,6 +13,7 @@
 #' # Read from disk
 #' \dontrun{
 #'   dat <- read_dataset_json("path/to/file.json")
+#'   dat <- dataset_json('https://www.somesite.com/file.json')
 #' }
 #'
 #' # Read from an already imported character vector
@@ -19,8 +21,15 @@
 #' js <- write_dataset_json(ds_json)
 #' dat <- read_dataset_json(js)
 read_dataset_json <- function(file) {
+
+  if (path_is_url(file)) {
+    file_contents <- read_from_url(file)
+  } else {
+    file_contents <- readLines(file)
+  }
+
   # Validate the input file against the schema
-  valid <- jsonvalidate::json_validate(file, schema_1_0_0, engine="ajv")
+  valid <- jsonvalidate::json_validate(file_contents, schema = schema_1_0_0, engine="ajv")
 
   if (!valid) {
     stop(paste0(c("Dataset JSON file is invalid per the JSON schema. ",
@@ -29,7 +38,7 @@ read_dataset_json <- function(file) {
   }
 
   # Read the file and convert to datasetjson object
-  ds_json <- jsonlite::fromJSON(file)
+  ds_json <- jsonlite::fromJSON(file_contents)
 
   # Pull the object out with a lot of assumptions because the format has already
   # been validated

--- a/R/read_dataset_json.R
+++ b/R/read_dataset_json.R
@@ -13,6 +13,7 @@
 #' # Read from disk
 #' \dontrun{
 #'   dat <- read_dataset_json("path/to/file.json")
+#'  # Read file from URL
 #'   dat <- dataset_json('https://www.somesite.com/file.json')
 #' }
 #'

--- a/R/utils.R
+++ b/R/utils.R
@@ -54,3 +54,29 @@ set_col_attr <- function(nm, d, attr, items) {
   attr(x, attr) <- items[items$name == nm,][[attr]]
   x
 }
+
+#' Check if given path is a URL
+#'
+#' @param path character string
+#'
+#' @return Boolean
+#' @noRd
+path_is_url <- function(path) {
+  grepl("^((http|ftp)s?|sftp|file)://", path)
+}
+
+#' Read data from a URL
+#'
+#' This function will let you pull data that's provided from a simple curl of a
+#' URL
+#'
+#' @param path valid URL string
+#'
+#' @return Contents of URL
+#' @noRd
+read_from_url <- function(path) {
+  con <- url(path, method = "libcurl")
+  x <- readLines(con, warn=FALSE) # the EOL warning shouldn't be a problem for readers
+  close(con)
+  x
+}

--- a/R/validate_dataset_json.R
+++ b/R/validate_dataset_json.R
@@ -1,10 +1,11 @@
 #' Validate a Dataset JSON file
 #'
-#' This function calls `jsonvalidate::json_validate()` directly, with the parameters
-#' necessary to retrieve the error information of an invalid JSON file per the
-#' Dataset JSON schema.
+#' This function calls `jsonvalidate::json_validate()` directly, with the
+#' parameters necessary to retrieve the error information of an invalid JSON
+#' file per the Dataset JSON schema.
 #'
-#' @param x Path to a Dataset JSON file or a character vector holding JSON text
+#' @param x File path or URL of a Dataset JSON file, or a character vector
+#'   holding JSON text
 #'
 #' @return A data frame
 #' @export
@@ -13,6 +14,7 @@
 #'
 #' \dontrun{
 #'   validate_dataset_json('path/to/file.json')
+#'   validate_dataset_json('https://www.somesite.com/file.json')
 #' }
 #'
 #' ds_json <- dataset_json(iris, "IG.IRIS", "IRIS", "Iris", iris_items)
@@ -20,7 +22,14 @@
 #'
 #' validate_dataset_json(js)
 validate_dataset_json <- function(x) {
-  v <- jsonvalidate::json_validate(x, schema_1_0_0, engine="ajv", verbose=TRUE)
+  # If contents are a URL then pull out the content
+  if (path_is_url(x)) {
+    js <- read_from_url(x)
+  } else {
+    js <- x
+  }
+
+  v <- jsonvalidate::json_validate(js, schema_1_0_0, engine="ajv", verbose=TRUE)
   if (!v) {
     warning("File contains errors!")
     return(attr(v, 'errors'))

--- a/man/read_dataset_json.Rd
+++ b/man/read_dataset_json.Rd
@@ -7,19 +7,21 @@
 read_dataset_json(file)
 }
 \arguments{
-\item{file}{File path on disk, or a pre-loaded Dataset JSON file in a single element character string}
+\item{file}{File path or URL of a Dataset JSON file}
 }
 \value{
 datasetjson object
 }
 \description{
-This function validated a dataset JSON file on disk against the Dataset JSON schema, and if valid
-returns a datasetjson object
+This function validates a dataset JSON file against the Dataset JSON schema,
+and if valid returns a datasetjson object. The Dataset JSON file can be
+either a file path on disk of a URL which contains the Dataset JSON file.
 }
 \examples{
 # Read from disk
 \dontrun{
   dat <- read_dataset_json("path/to/file.json")
+  dat <- dataset_json('https://www.somesite.com/file.json')
 }
 
 # Read from an already imported character vector

--- a/man/validate_dataset_json.Rd
+++ b/man/validate_dataset_json.Rd
@@ -7,20 +7,22 @@
 validate_dataset_json(x)
 }
 \arguments{
-\item{x}{Path to a Dataset JSON file or a character vector holding JSON text}
+\item{x}{File path or URL of a Dataset JSON file, or a character vector
+holding JSON text}
 }
 \value{
 A data frame
 }
 \description{
-This function calls \code{jsonvalidate::json_validate()} directly, with the parameters
-necessary to retrieve the error information of an invalid JSON file per the
-Dataset JSON schema.
+This function calls \code{jsonvalidate::json_validate()} directly, with the
+parameters necessary to retrieve the error information of an invalid JSON
+file per the Dataset JSON schema.
 }
 \examples{
 
 \dontrun{
   validate_dataset_json('path/to/file.json')
+  validate_dataset_json('https://www.somesite.com/file.json')
 }
 
 ds_json <- dataset_json(iris, "IG.IRIS", "IRIS", "Iris", iris_items)

--- a/tests/testthat/test-read_dataset_json.R
+++ b/tests/testthat/test-read_dataset_json.R
@@ -50,3 +50,13 @@ test_that("read_dataset_json matches xpt", {
   expect_equal(nrow(e), 87)
 
 })
+
+test_that("Dataset JSON can be read from a URL", {
+  file_path <- test_path("testdata", "ta.json")
+  url_file_path <- paste0("file://", normalizePath(test_path("testdata", "ta.json")))
+
+  from_disk <- read_dataset_json(file_path)
+  from_url <- read_dataset_json(url_file_path)
+
+  expect_equal(from_disk, from_url)
+})

--- a/tests/testthat/test-utils.R
+++ b/tests/testthat/test-utils.R
@@ -11,3 +11,20 @@ test_that("Type checker functions throw proper errors", {
 
   expect_error(set_item_data(1, iris), "Input must be a datasetjson or dataset_metadata object")
 })
+
+test_that("URL checker regex works as expected", {
+  url_list <- c(
+    "https://github.com/cdisc-org/DataExchange-DatasetJson/raw/master/examples/sdtm/ti.json", # true
+    "http://github.com/cdisc-org/DataExchange-DatasetJson/raw/master/examples/sdtm/ti.json",  # true
+    test_path("testdata", "ta.json"),                                                         # false
+    normalizePath(test_path("testdata", "ta.json")),                                          # false
+    paste0("file://", normalizePath(test_path("testdata", "ta.json"))),                       # true
+    paste0("ftp://", normalizePath(test_path("testdata", "ta.json"))),                        # true
+    paste0("ftps://", normalizePath(test_path("testdata", "ta.json"))),                       # true
+    paste0("sftp://", normalizePath(test_path("testdata", "ta.json")))                        # true
+  )
+
+  bool_check <- c(TRUE, TRUE, FALSE, FALSE, TRUE, TRUE, TRUE, TRUE)
+
+  expect_equal(path_is_url(url_list), bool_check)
+})

--- a/tests/testthat/test-validate_dataset_json.R
+++ b/tests/testthat/test-validate_dataset_json.R
@@ -6,3 +6,14 @@ test_that("validate_dataset_json returns correct messages", {
   expect_message(validate_dataset_json(js), "File is valid per the Dataset JSON v1.0.0 schema")
 
 })
+
+test_that("JSON can checked from URL", {
+  fpath <- paste0("file://", normalizePath(test_path("testdata", "ae.json")))
+  expect_warning(
+    err <- validate_dataset_json(fpath),
+    "File contains errors!"
+  )
+
+  # Loose check of number of issues
+  expect_equal(dim(err), c(87, 9))
+})


### PR DESCRIPTION
Example code:

```r
> validate_dataset_json("https://github.com/cdisc-org/DataExchange-DatasetJson/raw/master/examples/sdtm/ti.json")
File is valid per the Dataset JSON v1.0.0 schema

[1] instancePath schemaPath   keyword      params       message      schema       parentSchema dataPath    
<0 rows> (or 0-length row.names)
> head(read_dataset_json("https://github.com/cdisc-org/DataExchange-DatasetJson/raw/master/examples/sdtm/ti.json"))
       STUDYID DOMAIN IETESTCD
1 CDISCPILOT01     TI   INCL01
2 CDISCPILOT01     TI   INCL02
3 CDISCPILOT01     TI   INCL03
4 CDISCPILOT01     TI   INCL04
5 CDISCPILOT01     TI   INCL05
6 CDISCPILOT01     TI   INCL06
                                                                                                                  IETEST
1                                                             Males and postmenopausal females at least 50 years of age.
2                                                Diagnosis of probable AD as defined by NINCDS and the ADRDA guidelines.
3                                                                                                MMSE score of 10 to 23.
4                                                                       Modified Hachinski Ischemic Scale score of <= 4.
5 CNS imaging (CT scan or MRI of brain) compatible with AD within past 1 year. (See Protocol for incompatible findings.)
6   Investigator has obtained informed consent signed by the patient (and/or legal representative) and by the caregiver.
      IECAT   TIVERS
1 INCLUSION ORIGINAL
2 INCLUSION ORIGINAL
3 INCLUSION ORIGINAL
4 INCLUSION ORIGINAL
5 INCLUSION ORIGINAL
6 INCLUSION ORIGINAL
```

- Tests are added and coverage is kept at 100%
- NEWS.md has been updated
- DESCRIPTION has version updated to dev of 0.0.1.9000