### PR TITLE
Floats as decimals

### DIFF
--- a/R/read_dataset_json.R
+++ b/R/read_dataset_json.R
@@ -91,7 +91,9 @@ read_dataset_json <- function(file, decimals_as_floats=FALSE) {
   tdt <- items$targetDataType
   int_cols <- dt == "integer"
   if (decimals_as_floats) {
-    dbl_cols <- dt %in% c("float", "double", "decimal")
+    flt_cols <- dt %in% c("float", "double")
+    dec_cols <- dt == "decimal" & tdt == "decimal"
+    dbl_cols <- flt_cols | dec_cols
   } else {
     dbl_cols <- dt %in% c("float", "double")
   }

--- a/R/read_dataset_json.R
+++ b/R/read_dataset_json.R
@@ -52,7 +52,7 @@
 #' ds_json <- dataset_json(iris, "IG.IRIS", "IRIS", "Iris", columns=iris_items)
 #' js <- write_dataset_json(ds_json)
 #' dat <- read_dataset_json(js)
-read_dataset_json <- function(file, decimals_as_float=FALSE) {
+read_dataset_json <- function(file, decimals_as_floats=FALSE) {
 
   json_opts <- yyjsonr::opts_read_json(
     promote_num_to_string = TRUE
@@ -90,7 +90,7 @@ read_dataset_json <- function(file, decimals_as_float=FALSE) {
   dt <- items$dataType
   tdt <- items$targetDataType
   int_cols <- dt == "integer"
-  if (decimals_as_float) {
+  if (decimals_as_floats) {
     dbl_cols <- dt %in% c("float", "double", "decimal")
   } else {
     dbl_cols <- dt %in% c("float", "double")

--- a/R/read_dataset_json.R
+++ b/R/read_dataset_json.R
@@ -34,6 +34,7 @@
 #'these fields.
 #'
 #'@param file File path or URL of a Dataset JSON file
+#' @param decimals_as_float Convert variables of "decimal" type to float
 #'
 #'@return A dataframe with additional attributes attached containing the
 #'  DatasetJSON metadata.
@@ -51,7 +52,7 @@
 #' ds_json <- dataset_json(iris, "IG.IRIS", "IRIS", "Iris", columns=iris_items)
 #' js <- write_dataset_json(ds_json)
 #' dat <- read_dataset_json(js)
-read_dataset_json <- function(file) {
+read_dataset_json <- function(file, decimals_as_float=FALSE) {
 
   json_opts <- yyjsonr::opts_read_json(
     promote_num_to_string = TRUE
@@ -89,7 +90,11 @@ read_dataset_json <- function(file) {
   dt <- items$dataType
   tdt <- items$targetDataType
   int_cols <- dt == "integer"
-  dbl_cols <- dt %in% c("float", "double", "decimal")
+  if (decimals_as_float) {
+    dbl_cols <- dt %in% c("float", "double", "decimal")
+  } else {
+    dbl_cols <- dt %in% c("float", "double")
+  }
   bool_cols <- dt == "boolean"
   d[int_cols] <- lapply(d[int_cols], as.integer)
   d[dbl_cols] <- lapply(d[dbl_cols], as.double)

--- a/R/read_dataset_json.R
+++ b/R/read_dataset_json.R
@@ -34,7 +34,7 @@
 #'these fields.
 #'
 #'@param file File path or URL of a Dataset JSON file
-#' @param decimals_as_float Convert variables of "decimal" type to float
+#' @param decimals_as_floats Convert variables of "decimal" type to float
 #'
 #'@return A dataframe with additional attributes attached containing the
 #'  DatasetJSON metadata.

--- a/R/write_dataset_json.R
+++ b/R/write_dataset_json.R
@@ -126,7 +126,6 @@ write_dataset_json <- function(x, file, pretty=FALSE, float_as_decimals=FALSE, d
 
   # Create the JSON text
   json_opts <- yyjsonr::opts_write_json(
-    digits=19,
     pretty = pretty,
     auto_unbox = TRUE,
   )

--- a/R/write_dataset_json.R
+++ b/R/write_dataset_json.R
@@ -80,7 +80,7 @@ write_dataset_json <- function(x, file, pretty=FALSE, float_as_decimals=FALSE, d
         }
         x[y$name] <- strftime(as.numeric(x[[y$name]]), "%H:%M:%S", tz='UTC')
       }
-    } else if (float_as_decimals && y$dataType == "float") {
+    } else if (float_as_decimals && y$dataType %in% c("float", 'double', 'decimal')) {
       meta$columns[[i]]['dataType'] <- "decimal"
       meta$columns[[i]]['targetDataType'] <- "decimal"
       x[y$name] <- format(x[y$name], digits=digits)

--- a/README.Rmd
+++ b/README.Rmd
@@ -17,6 +17,8 @@ library(datasetjson)
 
 Welcome to **datasetjson**. **datasetjson** is an R package built to read and write [CDISC Dataset JSON](https://www.cdisc.org/standards/data-exchange/dataset-json) formatted datasets. 
 
+If you're stumbling into the world of Dataset JSON, you might be wondering "Why JSON?", as many have asked this question. We highly recommend you take a pit stop to read [this blog post](https://swhume.github.io/why-json-for-datasets) by Sam Hume one of the creators of the Dataset JSON standard. 
+
 As always, we welcome your feedback. If you spot a bug, would like to see a new feature, or if any documentation is unclear - submit an issue through GitHub right [here](https://github.com/atorus-research/datasetjson/issues). 
 
 # Installation

--- a/README.md
+++ b/README.md
@@ -14,6 +14,12 @@ read and write [CDISC Dataset
 JSON](https://www.cdisc.org/standards/data-exchange/dataset-json)
 formatted datasets.
 
+If you’re stumbling into the world of Dataset JSON, you might be
+wondering “Why JSON?”, as many have asked this question. We highly
+recommend you take a pit stop to read [this blog
+post](https://swhume.github.io/why-json-for-datasets) by Sam Hume one of
+the creators of the Dataset JSON standard.
+
 As always, we welcome your feedback. If you spot a bug, would like to
 see a new feature, or if any documentation is unclear - submit an issue
 through GitHub right
@@ -93,7 +99,7 @@ cat(js_text)
 ```
 
     ## {
-    ##   "datasetJSONCreationDateTime": "2025-01-24T16:34:20",
+    ##   "datasetJSONCreationDateTime": "2025-01-27T16:45:36",
     ##   "datasetJSONVersion": "1.1.0",
     ##   "fileOID": "/some/path",
     ##   "dbLastModifiedDateTime": "2025-01-21T13:34:50",

--- a/_pkgdown.yml
+++ b/_pkgdown.yml
@@ -56,3 +56,4 @@ articles:
   - date_time_datetime
   - converting_files
   - odm_details
+  - precision

--- a/man/read_dataset_json.Rd
+++ b/man/read_dataset_json.Rd
@@ -4,10 +4,12 @@
 \alias{read_dataset_json}
 \title{Read a Dataset JSON to datasetjson object}
 \usage{
-read_dataset_json(file)
+read_dataset_json(file, decimals_as_float = FALSE)
 }
 \arguments{
 \item{file}{File path or URL of a Dataset JSON file}
+
+\item{decimals_as_float}{Convert variables of "decimal" type to float}
 }
 \value{
 A dataframe with additional attributes attached containing the

--- a/man/read_dataset_json.Rd
+++ b/man/read_dataset_json.Rd
@@ -4,7 +4,7 @@
 \alias{read_dataset_json}
 \title{Read a Dataset JSON to datasetjson object}
 \usage{
-read_dataset_json(file, decimals_as_float = FALSE)
+read_dataset_json(file, decimals_as_floats = FALSE)
 }
 \arguments{
 \item{file}{File path or URL of a Dataset JSON file}

--- a/man/read_dataset_json.Rd
+++ b/man/read_dataset_json.Rd
@@ -9,7 +9,7 @@ read_dataset_json(file, decimals_as_floats = FALSE)
 \arguments{
 \item{file}{File path or URL of a Dataset JSON file}
 
-\item{decimals_as_float}{Convert variables of "decimal" type to float}
+\item{decimals_as_floats}{Convert variables of "decimal" type to float}
 }
 \value{
 A dataframe with additional attributes attached containing the

--- a/man/write_dataset_json.Rd
+++ b/man/write_dataset_json.Rd
@@ -4,7 +4,13 @@
 \alias{write_dataset_json}
 \title{Write out a Dataset JSON file}
 \usage{
-write_dataset_json(x, file, pretty = FALSE)
+write_dataset_json(
+  x,
+  file,
+  pretty = FALSE,
+  float_as_decimals = FALSE,
+  digits = 16
+)
 }
 \arguments{
 \item{x}{datasetjson object}
@@ -14,6 +20,17 @@ write_dataset_json(x, file, pretty = FALSE)
 \item{pretty}{If TRUE, write with readable formatting. \emph{Note: The Dataset
 JSON standard prefers compressed formatting without line feeds. It is not
 recommended you use pretty printing for submission purposes.}}
+
+\item{float_as_decimals}{If TRUE, Convert float variables to "decimal" data
+type in the JSON output. This will manually convert the numeric values
+using the \code{format()} function using the number of digits specified in
+\code{digits}, bypassing the \code{yyjsonr} handling of float values and writing the
+numbers out as JSON character strings. See the \href{https://wiki.cdisc.org/display/PUB/Precision+and+Rounding}{Dataset JSON user guide} for more
+information. Defaults to FALSE}
+
+\item{digits}{When using \code{float_as_decimals}, the number of digits to use
+when writing out floats. Going higher than 16 may start writing otherwise
+sufficiently precise decimals (i.e. .2) to long strings.}
 }
 \value{
 NULL when file written to disk, otherwise character string

--- a/tests/testthat/test-write_dataset_json.R
+++ b/tests/testthat/test-write_dataset_json.R
@@ -298,4 +298,40 @@ test_that("float_as_decimal works on read and write", {
   # Still to schema
   expect_message(validate_dataset_json(json_out1), "File is valid")
   expect_message(validate_dataset_json(json_out2), "File is valid")
+
+})
+
+test_that("Decimal won't convert unless target data type is set", {
+
+  test_df <- head(iris, 5)
+  test_df['float_col'] <- as.character(c(
+    143.66666666666699825,
+    2/3,
+    1/3,
+    165/37,
+    6/7
+  ))
+
+  test_items <- iris_items |> dplyr::bind_rows(
+    data.frame(
+      itemOID = "IT.IR.float_col",
+      name = "float_col",
+      label = "Test column long decimal",
+      dataType = "decimal"
+    )
+  )
+
+  dsjson <- dataset_json(
+    test_df,
+    item_oid = "test_df",
+    name = "test_df",
+    dataset_label = "test_df",
+    columns = test_items
+  )
+
+  json_out <- write_dataset_json(dsjson, float_as_decimals = TRUE)
+
+  out <- read_dataset_json(json_out)
+
+  expect_true(inherits(out$float_col, "character"))
 })

--- a/tests/testthat/test-write_dataset_json.R
+++ b/tests/testthat/test-write_dataset_json.R
@@ -255,7 +255,7 @@ test_that("Writing errors trigger", {
 
 })
 
-test_that("float_as_decimal works on read and write" {
+test_that("float_as_decimal works on read and write", {
 
   test_df <- head(iris, 5)
   test_df['float_col'] <- c(
@@ -266,7 +266,7 @@ test_that("float_as_decimal works on read and write" {
     6/7
   )
 
-  test_items <- iris_items |> bind_rows(
+  test_items <- iris_items |> dplyr::bind_rows(
     data.frame(
       itemOID = "IT.IR.float_col",
       name = "float_col",

--- a/tests/testthat/test-write_dataset_json.R
+++ b/tests/testthat/test-write_dataset_json.R
@@ -254,3 +254,48 @@ test_that("Writing errors trigger", {
   expect_error(write_dataset_json(ds_json3), "If dataType is date")
 
 })
+
+test_that("float_as_decimal works on read and write" {
+
+  test_df <- head(iris, 5)
+  test_df['float_col'] <- c(
+    143.66666666666699825,
+    2/3,
+    1/3,
+    165/37,
+    6/7
+  )
+
+  test_items <- iris_items |> bind_rows(
+    data.frame(
+      itemOID = "IT.IR.float_col",
+      name = "float_col",
+      label = "Test column long decimal",
+      dataType = "float"
+    )
+  )
+
+  dsjson <- dataset_json(
+    test_df,
+    item_oid = "test_df",
+    name = "test_df",
+    dataset_label = "test_df",
+    columns = test_items
+  )
+
+  json_out1 <- write_dataset_json(dsjson, float_as_decimals = FALSE)
+  json_out2 <- write_dataset_json(dsjson, float_as_decimals = TRUE)
+
+  out1 <- read_dataset_json(json_out1)
+  out2 <- read_dataset_json(json_out2, decimals_as_float = TRUE)
+
+  # Expect precision to fall apart around 7 decimal place
+  expect_true(all(abs(out1$float_col - test_df$float_col) > 0.0000001))
+
+  # Should be rectified by manual decimal conversions
+  expect_equal(out2$float_col, test_df$float_col,ignore_attr = TRUE)
+
+  # Still to schema
+  expect_message(validate_dataset_json(json_out1), "File is valid")
+  expect_message(validate_dataset_json(json_out2), "File is valid")
+})

--- a/vignettes/precision.Rmd
+++ b/vignettes/precision.Rmd
@@ -1,0 +1,97 @@
+---
+title: "Numeric Precision"
+output: rmarkdown::html_vignette
+vignette: >
+  %\VignetteIndexEntry{precision}
+  %\VignetteEngine{knitr::rmarkdown}
+  %\VignetteEncoding{UTF-8}
+---
+
+```{r, include = FALSE}
+knitr::opts_chunk$set(
+  collapse = TRUE,
+  comment = "#>"
+)
+```
+
+Numeric precision and issues with floating point decimals is a common problem to come across when working with data. Dataset JSON is not immune to these issues. Instead of writing out direct binary representations of the floating point numbers, which will vary depending on the system being used and the standard followed, Dataset JSON writes out character representations of these numbers. As such, when the numbers are serialized from numeric to character, and then read back into numeric format, you may come across precision issues.
+
+Consider the following example:
+
+```{r example}
+library(datasetjson)
+library(dplyr)
+
+test_df <- head(iris, 5)
+test_df['float_col'] <- c(
+  143.66666666666699825,
+  2/3,
+  1/3,
+  165/37,
+  6/7
+)
+
+test_items <- iris_items |> bind_rows(
+  data.frame(
+    itemOID = "IT.IR.float_col",
+    name = "float_col",
+    label = "Test column long decimal",
+    dataType = "float"
+  )
+)
+
+dsjson <- dataset_json(
+  test_df, 
+  item_oid = "test_df",
+  name = "test_df",
+  dataset_label = "test_df",
+  columns = test_items
+)
+
+json_out <-write_dataset_json(dsjson)
+
+out <- read_dataset_json(json_out)
+
+test_df$float_col - out$float_col
+```
+
+In this case, we start seeing differences at the 7th decimal point. To look at a specific value, the input of `143.66666666666699825` is written out in the JSON file as `143.666666666667`. This issue isn't unique to R either. If you're ever converted numeric to character and back to numeric in SAS, you'll likely have encountered a similar problem.
+
+In the **{datasetjson}** package, the **{yyjsonr}** package is doing the heavy lifting of serializing the R numeric value into a character string. The underlying C library has some [recent updates](https://github.com/ibireme/yyjson/commit/6d416047822d86d53a3a0b45a6a5abf28383a1dc) to work on improving read output number precision which we hope will improve the handling.
+
+Another way to handle numeric precision issues is to use the "decimal" types that's available in the Dataset JSON standard. From the [user guide](https://wiki.cdisc.org/display/PUB/Precision+and+Rounding), this can be described as follows:
+
+> ## Decimal Data Type
+>
+> Although the pilot findings on precision and rounding did not point to a problem with Dataset-JSON, the Dataset-JSON Team opted to add the Decimal datatype. The Decimal datatype has been available in ODM for many years. The basic premise for this datatype is to represent the number in Dataset-JSON as a string (a quoted set of numeric characters) to prevent JSON libraries from interpreting the number as a float before the software application gets access to it.
+>
+> To use decimal in Dataset-JSON, set the dataType to decimal and the targetDataType to decimal. This instructs conversion software to convert the number it reads from a native dataset into a string in Dataset-JSON. It also instructs the receiver to convert the number as a string into the decimal datatype or closest approximation available in the receiving technology. Note that not all technologies support an explicit decimal datatype.
+
+In order to address this problem, we've added the options `floats_as_decimals` and `digits` to `write_dataset_json()` and `decimals_as_floats` to `read_dataset_json()`. 
+
+Considering the example before, here's how these options can help.
+
+```{r conversion}
+json_out <-write_dataset_json(dsjson, float_as_decimals = TRUE)
+
+out <- read_dataset_json(json_out, decimals_as_floats = TRUE)
+
+test_df$float_col - out$float_col
+```
+
+By manually handling how the decimal precision is rendered, the values were able to serialize and re-import more effectively. 
+
+There are a few reasons we've chosen to NOT make this default behavior:
+
+- This inherently adds overhead, because we convert the values prior to letting `yyjsonr` serialize them
+- We're changing the way the metadata is writing to use the `decimal` type. While the standard supports the use of the `decimal` type, it's an extra step that that the consuming system needs to be aware of, and Dataset JSON is still a young standard. 
+- Our hope is that the `yyjson` C package grows to make this extra step less necessary
+
+As one last note, we default our choice of decimal precision to use 16 digits. The reason we've chosen to do this is as follows:
+
+```{r digits}
+print(format(.2, digits=16))
+print(format(.2, digits=17))
+```
+
+After a certain point, displaying extra digits is just going to show the where floating point values start to break down. 16 digits balances preserving the precision of output without turning low precision numbers into overly precise ones.


### PR DESCRIPTION
This adds the `floats_as_decimals` option to `write_dataset_json()` and `decimals_as_floats` option to `read_dataset_json()` to address precision issues found in testing.

A vignette explains the problem and solution, and tests have been added to verify that:

- The function does what's intended
- Defaults work ok, and
- Schemas are valid with the changed use of metadata. 